### PR TITLE
fixed if statements and cut commands

### DIFF
--- a/slack.sh
+++ b/slack.sh
@@ -11,24 +11,24 @@ username='Zabbix'
 
 # Get the Slack channel or user ($1), Zabbix subject (hopefully either PROBLEM or RECOVERY), and the server in question
 to="$1"
-subject=$(echo $2|cut -d' ' -f1) # The alert type is before the space, server after, eg
-server=$(echo $2|cut -d' ' -f2-) #      "Subject: PROBLEM SomeDatabaseServer01"
+subject=$(echo $2 | cut -d ':' -f 1) # The alert type is before the space, server after, eg
+server=$(echo $2 | cut -d ' ' -f 5) #      "Subject: PROBLEM SomeDatabaseServer01"
 
 # Set up the alert type (future flexibility)
-if [ "$subject" == 'RECOVERY' ]; then
+if [ "$subject" == "Resolved" ]; then
         type="R"
-elif [ "$subject" == 'PROBLEM' ]; then
+elif [ "$subject" == "Problem" ]; then
         type="P"
 else
         type="N"
 fi
 
 # Change message emoji, color, and (friendly) status depending on the subject
-if [ $type == 'R' ]; then  # Triggered by 'RECOVERY' above
+if [ "$type" == "R" ]; then  # Triggered by 'RECOVERY' above
         emoji=':smile:'    # A smile,
         color="#20E020"    # and red text
         status="Recovered"
-elif [ $type == 'P' ]; then  # Triggered by 'PROBLEM' above
+elif [ "$type" == "P" ]; then  # Triggered by 'PROBLEM' above
         emoji=':frowning:'
         color="#E02020"
         status="Problem"


### PR DESCRIPTION
if statements for `type` were looking for all caps values, changed those to what Zabbix 3.4 sends as arguments "e.g. Problem". Changed recovery to resolved.

Fixed cut to grab the desired values - changed delimiter on `subject` to `:` and changed field on `server` to 5. Also made them a little easier to read.

Double quoted `$type` variable in if statements